### PR TITLE
Handle populating genres in Detail screen.

### DIFF
--- a/app/src/androidTest/java/com/balocco/androidcomponents/MoviesDaoTest.kt
+++ b/app/src/androidTest/java/com/balocco/androidcomponents/MoviesDaoTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.runner.AndroidJUnit4
 import com.balocco.androidcomponents.data.local.AppDatabase
 import com.balocco.androidcomponents.data.local.MoviesDao
+import com.balocco.androidcomponents.data.model.Genre
 import com.balocco.androidcomponents.data.model.Movie
 import org.junit.After
 import org.junit.Before
@@ -72,6 +73,16 @@ class MoviesDaoTest {
         dao.insertMovies(listOf(movieOne, movieTwo)).test()
 
         dao.queryAllMoviesSortedByRating().test().assertValue(listOf(movieTwo, movieOne))
+    }
+
+    @Test
+    fun fetchAGenresWithId_returnsOnlyGenresWithSpecifiedIds() {
+        val genre1 = Genre(1, "Action")
+        val genre2 = Genre(2, "Adventure")
+        val genre3 = Genre(3, "Sci-Fi")
+        dao.insertGenres(listOf(genre1, genre2, genre3)).test()
+
+        dao.queryGenres(listOf(1, 3)).test().assertValue(listOf(genre1, genre3))
     }
 
     private fun givenMovie(

--- a/app/src/main/java/com/balocco/androidcomponents/data/MoviesRepository.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/data/MoviesRepository.kt
@@ -1,6 +1,8 @@
 package com.balocco.androidcomponents.data
 
 import com.balocco.androidcomponents.data.local.LocalDataSource
+import com.balocco.androidcomponents.data.model.Genre
+import com.balocco.androidcomponents.data.model.Genres
 import com.balocco.androidcomponents.data.model.Movie
 import com.balocco.androidcomponents.data.model.MoviesPage
 import com.balocco.androidcomponents.data.remote.RemoteDataSource
@@ -22,4 +24,11 @@ class MoviesRepository @Inject constructor(
 
     fun fetchTopRatedMovies(page: Int = 1): Single<MoviesPage> =
         remoteDataSource.fetchTopRatedMovies(page)
+
+    fun loadGenres(ids: List<Int>): Flowable<List<Genre>> = localDataSource.fetchGenres(ids)
+
+    fun storeGenres(genres: List<Genre>): Completable = localDataSource.insertGenres(genres)
+
+    fun fetchGenres(): Single<Genres> = remoteDataSource.fetchGenres()
+
 }

--- a/app/src/main/java/com/balocco/androidcomponents/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/data/local/AppDatabase.kt
@@ -3,9 +3,13 @@ package com.balocco.androidcomponents.data.local
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import com.balocco.androidcomponents.data.model.Genre
 import com.balocco.androidcomponents.data.model.Movie
 
-@Database(entities = arrayOf(Movie::class), version = 1)
+@Database(
+    entities = [Movie::class, Genre::class],
+    version = 1
+)
 @TypeConverters(ListTypeConverter::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun moviesDao(): MoviesDao

--- a/app/src/main/java/com/balocco/androidcomponents/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/data/local/LocalDataSource.kt
@@ -1,5 +1,6 @@
 package com.balocco.androidcomponents.data.local
 
+import com.balocco.androidcomponents.data.model.Genre
 import com.balocco.androidcomponents.data.model.Movie
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
@@ -14,5 +15,9 @@ interface LocalDataSource {
     fun fetchAllMoviesSortedByRating(): Flowable<List<Movie>>
 
     fun fetchMovie(id: String): Single<Movie>
+
+    fun insertGenres(genres: List<Genre>): Completable
+
+    fun fetchGenres(ids: List<Int>): Flowable<List<Genre>>
 
 }

--- a/app/src/main/java/com/balocco/androidcomponents/data/local/MoviesDao.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/data/local/MoviesDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import com.balocco.androidcomponents.data.model.Genre
 import com.balocco.androidcomponents.data.model.Movie
 import io.reactivex.Completable
 import io.reactivex.Flowable
@@ -24,8 +25,13 @@ interface MoviesDao {
     @Query("SELECT * FROM ${Movie.TABLE_NAME} WHERE ${Movie.COLUMN_ID} = :id")
     fun queryMovieWithId(id: String): Single<Movie>
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertGenres(genres: List<Genre>): Completable
+
+    @Query("SELECT * FROM ${Genre.TABLE_NAME} WHERE ${Genre.COLUMN_ID} IN (:ids)")
+    fun queryGenres(ids: List<Int>): Flowable<List<Genre>>
+
     companion object {
         const val DATABASE_NAME = "moviesDatabase"
     }
-
 }

--- a/app/src/main/java/com/balocco/androidcomponents/data/local/MoviesLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/data/local/MoviesLocalDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.balocco.androidcomponents.data.local
 
+import com.balocco.androidcomponents.data.model.Genre
 import com.balocco.androidcomponents.data.model.Movie
 import hu.akarnokd.rxjava3.bridge.RxJavaBridge
 import io.reactivex.rxjava3.core.Completable
@@ -21,5 +22,11 @@ class MoviesLocalDataSourceImpl(
 
     override fun fetchMovie(id: String): Single<Movie> =
         RxJavaBridge.toV3Single(dao.queryMovieWithId(id))
+
+    override fun insertGenres(genres: List<Genre>): Completable =
+        RxJavaBridge.toV3Completable(dao.insertGenres(genres))
+
+    override fun fetchGenres(ids: List<Int>): Flowable<List<Genre>> =
+        RxJavaBridge.toV3Flowable(dao.queryGenres(ids))
 
 }

--- a/app/src/main/java/com/balocco/androidcomponents/data/model/Genre.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/data/model/Genre.kt
@@ -1,0 +1,21 @@
+package com.balocco.androidcomponents.data.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.google.gson.annotations.SerializedName
+
+@Entity(tableName = Genre.TABLE_NAME)
+data class Genre(
+    @PrimaryKey @ColumnInfo(name = COLUMN_ID)
+    @SerializedName("id")
+    val id: Int,
+    @ColumnInfo(name = "name")
+    @SerializedName("name")
+    val name: String
+) {
+    companion object {
+        const val TABLE_NAME = "genre"
+        const val COLUMN_ID = "uid"
+    }
+}

--- a/app/src/main/java/com/balocco/androidcomponents/data/model/Genres.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/data/model/Genres.kt
@@ -1,0 +1,7 @@
+package com.balocco.androidcomponents.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class Genres(
+    @SerializedName("genres") val genres: List<Genre>
+)

--- a/app/src/main/java/com/balocco/androidcomponents/data/model/Movie.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/data/model/Movie.kt
@@ -42,7 +42,7 @@ data class Movie(
     val popularity: Double
 ) {
     companion object {
-        const val TABLE_NAME = "birthdays"
+        const val TABLE_NAME = "movies"
         const val COLUMN_ID = "uid"
         const val COLUMN_VOTE_AVERAGE = "vote_average"
     }

--- a/app/src/main/java/com/balocco/androidcomponents/data/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/data/remote/RemoteDataSource.kt
@@ -1,5 +1,6 @@
 package com.balocco.androidcomponents.data.remote
 
+import com.balocco.androidcomponents.data.model.Genres
 import com.balocco.androidcomponents.data.model.MoviesPage
 import io.reactivex.rxjava3.core.Single
 import retrofit2.http.GET
@@ -13,8 +14,11 @@ interface RemoteDataSource {
     @GET("${API_VERSION}/movie/top_rated")
     fun fetchTopRatedMovies(@Query("page") page: Int = 1): Single<MoviesPage>
 
+    @GET("${API_VERSION}/genre/movie/list")
+    fun fetchGenres(): Single<Genres>
+
     companion object {
-        val BASE_URL = BASE_URL_INTERNAL
-        val BASE_IMAGE_URL = BASE_IMAGE_URL_INTERNAL
+        const val BASE_URL = BASE_URL_INTERNAL
+        const val BASE_IMAGE_URL = BASE_IMAGE_URL_INTERNAL
     }
 }

--- a/app/src/main/java/com/balocco/androidcomponents/feature/detail/domain/FetchGenresUseCase.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/feature/detail/domain/FetchGenresUseCase.kt
@@ -1,0 +1,18 @@
+package com.balocco.androidcomponents.feature.detail.domain
+
+import com.balocco.androidcomponents.data.MoviesRepository
+import io.reactivex.rxjava3.core.Completable
+import javax.inject.Inject
+
+class FetchGenresUseCase @Inject constructor(
+    private val repository: MoviesRepository
+) {
+
+    operator fun invoke(): Completable {
+        return repository.fetchGenres()
+            .onErrorComplete()
+            .flatMapCompletable { result ->
+                repository.storeGenres(result.genres)
+            }
+    }
+}

--- a/app/src/main/java/com/balocco/androidcomponents/feature/detail/domain/GenresFormatter.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/feature/detail/domain/GenresFormatter.kt
@@ -1,0 +1,18 @@
+package com.balocco.androidcomponents.feature.detail.domain
+
+import com.balocco.androidcomponents.data.model.Genre
+import javax.inject.Inject
+
+class GenresFormatter @Inject constructor() {
+
+    fun toList(genres: List<Genre>): String {
+        val builder = StringBuilder()
+        for (genre in genres) {
+            if (builder.isNotEmpty()) {
+                builder.append(", ")
+            }
+            builder.append(genre.name)
+        }
+        return builder.toString()
+    }
+}

--- a/app/src/main/java/com/balocco/androidcomponents/feature/detail/domain/LoadGenresUseCase.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/feature/detail/domain/LoadGenresUseCase.kt
@@ -1,0 +1,14 @@
+package com.balocco.androidcomponents.feature.detail.domain
+
+import com.balocco.androidcomponents.data.MoviesRepository
+import com.balocco.androidcomponents.data.model.Genre
+import io.reactivex.rxjava3.core.Flowable
+import javax.inject.Inject
+
+class LoadGenresUseCase @Inject constructor(
+    private val repository: MoviesRepository
+) {
+
+    operator fun invoke(ids: List<Int>): Flowable<List<Genre>> = repository.loadGenres(ids)
+
+}

--- a/app/src/main/java/com/balocco/androidcomponents/feature/detail/ui/DetailActivity.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/feature/detail/ui/DetailActivity.kt
@@ -27,17 +27,15 @@ private const val KEY_MOVIE_ID = "KEY_MOVIE_ID"
 
 class DetailActivity : BaseActivity() {
 
-    @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-
-    @Inject
-    lateinit var imageLoader: ImageLoader
+    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var imageLoader: ImageLoader
 
     private lateinit var backdropImage: ImageView
     private lateinit var voteAverageText: TextView
     private lateinit var voteCountText: TextView
     private lateinit var collapsingToolbar: CollapsingToolbarLayout
     private lateinit var overviewText: TextView
+    private lateinit var genresText: TextView
     private lateinit var releaseDateText: TextView
     private lateinit var originalLanguageText: TextView
     private lateinit var viewModel: DetailViewModel
@@ -51,6 +49,7 @@ class DetailActivity : BaseActivity() {
         voteAverageText = findViewById(R.id.vote)
         voteCountText = findViewById(R.id.vote_count)
         overviewText = findViewById(R.id.overview)
+        genresText = findViewById(R.id.genres)
         releaseDateText = findViewById(R.id.release_date)
         originalLanguageText = findViewById(R.id.original_language)
 
@@ -86,7 +85,7 @@ class DetailActivity : BaseActivity() {
         when (state.state) {
             State.LOADING -> {
             }
-            State.SUCCESS -> populateView(state.movie)
+            State.SUCCESS -> populateView(state.movie, state.genres)
             State.ERROR -> {
                 Toast.makeText(this, state.errorMessage, Toast.LENGTH_SHORT).show()
                 onBackPressed()
@@ -94,7 +93,7 @@ class DetailActivity : BaseActivity() {
         }
     }
 
-    private fun populateView(movie: Movie?) {
+    private fun populateView(movie: Movie?, genres: String) {
         movie?.let {
             imageLoader.loadImage(backdropImage, movie.backdropImageName)
             collapsingToolbar.title = movie.title
@@ -103,6 +102,10 @@ class DetailActivity : BaseActivity() {
             overviewText.text = movie.overview
             releaseDateText.text = movie.releaseDate
             originalLanguageText.text = movie.originalLanguage.toUpperCase(Locale.ENGLISH)
+        }
+
+        if (genres.isNotEmpty()) {
+            genresText.text = genres
         }
     }
 

--- a/app/src/main/java/com/balocco/androidcomponents/feature/detail/viewmodel/DetailState.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/feature/detail/viewmodel/DetailState.kt
@@ -7,5 +7,6 @@ import com.balocco.androidcomponents.data.model.Movie
 data class DetailState(
     val state: State,
     val movie: Movie? = null,
+    val genres: String,
     @StringRes val errorMessage: Int = 0
 )

--- a/app/src/main/java/com/balocco/androidcomponents/feature/detail/viewmodel/DetailViewModel.kt
+++ b/app/src/main/java/com/balocco/androidcomponents/feature/detail/viewmodel/DetailViewModel.kt
@@ -6,17 +6,26 @@ import com.balocco.androidcomponents.R
 import com.balocco.androidcomponents.common.scheduler.SchedulerProvider
 import com.balocco.androidcomponents.common.viewmodel.BaseViewModel
 import com.balocco.androidcomponents.common.viewmodel.State
+import com.balocco.androidcomponents.data.model.Genre
 import com.balocco.androidcomponents.data.model.Movie
+import com.balocco.androidcomponents.feature.detail.domain.FetchGenresUseCase
+import com.balocco.androidcomponents.feature.detail.domain.GenresFormatter
+import com.balocco.androidcomponents.feature.detail.domain.LoadGenresUseCase
 import com.balocco.androidcomponents.feature.detail.domain.LoadMovieUseCase
 import io.reactivex.rxjava3.kotlin.addTo
 import javax.inject.Inject
 
 class DetailViewModel @Inject constructor(
     private val schedulerProvider: SchedulerProvider,
-    private val loadMovieUseCase: LoadMovieUseCase
+    private val loadMovieUseCase: LoadMovieUseCase,
+    private val fetchGenresUseCase: FetchGenresUseCase,
+    private val loadGenresUseCase: LoadGenresUseCase,
+    private val genresFormatter: GenresFormatter
 ) : BaseViewModel() {
 
     private var detailState: MutableLiveData<DetailState> = MutableLiveData()
+    private var movie: Movie? = null
+    private var genres: String = ""
 
     fun detailState(): LiveData<DetailState> = detailState
 
@@ -31,13 +40,37 @@ class DetailViewModel @Inject constructor(
     }
 
     private fun handleMovie(movie: Movie) {
-        detailState.value = DetailState(State.SUCCESS, movie)
-        // Load genres
+        this.movie = movie
+        detailState.value = DetailState(State.SUCCESS, movie, genres)
+
+        loadGenresUseCase(movie.genres)
+            .subscribeOn(schedulerProvider.io())
+            .observeOn(schedulerProvider.ui())
+            .subscribe(
+                { genres -> handleGenresResult(genres) },
+                { error -> { /* Handle failure in fetching genres, for now we can ignore */ } }
+            ).addTo(compositeDisposable)
+    }
+
+    private fun handleGenresResult(genres: List<Genre>) {
+        // TODO: we could improve by comparing number of received genres locally with movie genres
+        if (genres.isEmpty()) {
+            fetchGenresUseCase()
+                .subscribeOn(schedulerProvider.io())
+                .observeOn(schedulerProvider.ui())
+                .subscribe().addTo(compositeDisposable)
+            return
+        }
+
+        this.genres = genresFormatter.toList(genres)
+        detailState.value = DetailState(State.SUCCESS, movie, this.genres)
     }
 
     private fun handleError() {
         detailState.value = DetailState(
             state = State.ERROR,
+            movie = movie,
+            genres = genres,
             errorMessage = R.string.error_loading_movie
         )
     }

--- a/app/src/main/res/layout/detail_activity.xml
+++ b/app/src/main/res/layout/detail_activity.xml
@@ -150,6 +150,7 @@
                 android:text="@string/detail_genres" />
 
             <TextView
+                android:id="@+id/genres"
                 style="@style/DetailDescriptionTextStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/test/java/com/balocco/androidcomponents/TestUtils.kt
+++ b/app/src/test/java/com/balocco/androidcomponents/TestUtils.kt
@@ -4,7 +4,10 @@ import com.balocco.androidcomponents.data.model.Movie
 
 object TestUtils {
 
-    fun createMovie(id: String): Movie =
+    fun createMovie(
+        id: String,
+        genres: List<Int> = listOf()
+    ): Movie =
         Movie(
             id = id,
             title = "Title",
@@ -14,7 +17,7 @@ object TestUtils {
             releaseDate = "11-10-2020",
             backdropImageName = "backdrop.jpg",
             posterImageName = "poster.jpg",
-            genres = mutableListOf(),
+            genres = genres,
             voteCount = 100,
             popularity = 123.0
         )

--- a/app/src/test/java/com/balocco/androidcomponents/data/MoviesRepositoryTest.kt
+++ b/app/src/test/java/com/balocco/androidcomponents/data/MoviesRepositoryTest.kt
@@ -2,6 +2,8 @@ package com.balocco.androidcomponents.data
 
 import com.balocco.androidcomponents.TestUtils
 import com.balocco.androidcomponents.data.local.LocalDataSource
+import com.balocco.androidcomponents.data.model.Genre
+import com.balocco.androidcomponents.data.model.Genres
 import com.balocco.androidcomponents.data.model.MoviesPage
 import com.balocco.androidcomponents.data.remote.RemoteDataSource
 import com.nhaarman.mockito_kotlin.whenever
@@ -15,11 +17,8 @@ import org.mockito.MockitoAnnotations
 
 class MoviesRepositoryTest {
 
-    @Mock
-    lateinit var localDataSource: LocalDataSource
-
-    @Mock
-    lateinit var remoteDataSource: RemoteDataSource
+    @Mock lateinit var localDataSource: LocalDataSource
+    @Mock lateinit var remoteDataSource: RemoteDataSource
 
     private lateinit var repository: MoviesRepository
 
@@ -78,5 +77,30 @@ class MoviesRepositoryTest {
         whenever(remoteDataSource.fetchTopRatedMovies(3)).thenReturn(Single.just(moviesPage))
 
         repository.fetchTopRatedMovies(3).test().assertResult(moviesPage)
+    }
+
+    @Test
+    fun `When loading genres, loads genres from local data source`() {
+        val genre = Genre(1, "Action")
+        whenever(localDataSource.fetchGenres(listOf(1))).thenReturn(Flowable.just(listOf(genre)))
+
+        repository.loadGenres(listOf(1)).test().assertResult(listOf(genre))
+    }
+
+    @Test
+    fun `When storing genres, store genres in local data source`() {
+        val genre = Genre(1, "Action")
+        whenever(localDataSource.insertGenres(listOf(genre))).thenReturn(Completable.complete())
+
+        repository.storeGenres(listOf(genre)).test().assertComplete()
+    }
+
+    @Test
+    fun `When fetching genres, fetches genres from remote data source`() {
+        val genre = Genre(1, "Action")
+        val genres = Genres(listOf(genre))
+        whenever(remoteDataSource.fetchGenres()).thenReturn(Single.just(genres))
+
+        repository.fetchGenres().test().assertValue(genres)
     }
 }

--- a/app/src/test/java/com/balocco/androidcomponents/feature/detail/domain/FetchGenresUseCaseTest.kt
+++ b/app/src/test/java/com/balocco/androidcomponents/feature/detail/domain/FetchGenresUseCaseTest.kt
@@ -1,0 +1,50 @@
+package com.balocco.androidcomponents.feature.detail.domain
+
+import com.balocco.androidcomponents.data.MoviesRepository
+import com.balocco.androidcomponents.data.model.Genre
+import com.balocco.androidcomponents.data.model.Genres
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Single
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+
+class FetchGenresUseCaseTest {
+
+    @Mock lateinit var moviesRepository: MoviesRepository
+
+    private lateinit var useCase: FetchGenresUseCase
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+
+        useCase = FetchGenresUseCase(moviesRepository)
+    }
+
+    @Test
+    fun `When fetching genres successfully, stores genres in repository`() {
+        val genres = listOf(Genre(1, "Action"))
+        val genresResponse = Genres(genres)
+        whenever(moviesRepository.fetchGenres()).thenReturn(Single.just(genresResponse))
+        whenever(moviesRepository.storeGenres(genres)).thenReturn(Completable.complete())
+
+        useCase().test().assertComplete()
+
+        verify(moviesRepository).storeGenres(genres)
+    }
+
+    @Test
+    fun `When fetching genres with error, notify complete and does not store genres`() {
+        whenever(moviesRepository.fetchGenres()).thenReturn(Single.error(Throwable()))
+
+        useCase().test().assertComplete()
+
+        verify(moviesRepository, never()).storeGenres(any())
+    }
+}

--- a/app/src/test/java/com/balocco/androidcomponents/feature/detail/domain/GenresFormatterTest.kt
+++ b/app/src/test/java/com/balocco/androidcomponents/feature/detail/domain/GenresFormatterTest.kt
@@ -1,0 +1,41 @@
+package com.balocco.androidcomponents.feature.detail.domain
+
+import com.balocco.androidcomponents.data.model.Genre
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class GenresFormatterTest {
+
+    private lateinit var formatter: GenresFormatter
+
+    @Before
+    fun setUp() {
+        formatter = GenresFormatter()
+    }
+
+    @Test
+    fun `When formatting empty list of genres, returns empty string`() {
+        val formattedResult = formatter.toList(emptyList())
+
+        assertEquals("", formattedResult)
+    }
+
+    @Test
+    fun `When formatting list with single enty, returns genre`() {
+        val genre = Genre(1, "Action")
+        val formattedResult = formatter.toList(listOf(genre))
+
+        assertEquals("Action", formattedResult)
+    }
+
+    @Test
+    fun `When formatting list with multiple enties, returns genres comma separated`() {
+        val genre1 = Genre(1, "Action")
+        val genre2 = Genre(2, "Adventure")
+        val formattedResult = formatter.toList(listOf(genre1, genre2))
+
+        assertEquals("Action, Adventure", formattedResult)
+    }
+
+}

--- a/app/src/test/java/com/balocco/androidcomponents/feature/detail/domain/LoadGenresUseCaseTest.kt
+++ b/app/src/test/java/com/balocco/androidcomponents/feature/detail/domain/LoadGenresUseCaseTest.kt
@@ -1,0 +1,32 @@
+package com.balocco.androidcomponents.feature.detail.domain
+
+import com.balocco.androidcomponents.data.MoviesRepository
+import com.balocco.androidcomponents.data.model.Genre
+import com.nhaarman.mockito_kotlin.whenever
+import io.reactivex.rxjava3.core.Flowable
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+
+class LoadGenresUseCaseTest {
+
+    @Mock lateinit var moviesRepository: MoviesRepository
+
+    private lateinit var useCase: LoadGenresUseCase
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+
+        useCase = LoadGenresUseCase(moviesRepository)
+    }
+
+    @Test
+    fun `When loading genres ids, returns genres from local data source`() {
+        val genre = Genre(1, "Action")
+        whenever(moviesRepository.loadGenres(listOf(1))).thenReturn(Flowable.just(listOf(genre)))
+
+        useCase(listOf(1)).test().assertResult(listOf(genre))
+    }
+}

--- a/app/src/test/java/com/balocco/androidcomponents/feature/detail/domain/LoadMovieUseCaseTest.kt
+++ b/app/src/test/java/com/balocco/androidcomponents/feature/detail/domain/LoadMovieUseCaseTest.kt
@@ -11,8 +11,7 @@ import org.mockito.MockitoAnnotations
 
 class LoadMovieUseCaseTest {
 
-    @Mock
-    lateinit var moviesRepository: MoviesRepository
+    @Mock lateinit var moviesRepository: MoviesRepository
 
     private lateinit var useCase: LoadMovieUseCase
 

--- a/app/src/test/java/com/balocco/androidcomponents/feature/detail/viewmodel/DetailViewModelTest.kt
+++ b/app/src/test/java/com/balocco/androidcomponents/feature/detail/viewmodel/DetailViewModelTest.kt
@@ -6,9 +6,16 @@ import com.balocco.androidcomponents.R
 import com.balocco.androidcomponents.TestUtils
 import com.balocco.androidcomponents.common.scheduler.TestSchedulerProvider
 import com.balocco.androidcomponents.common.viewmodel.State
+import com.balocco.androidcomponents.data.model.Genre
+import com.balocco.androidcomponents.feature.detail.domain.FetchGenresUseCase
+import com.balocco.androidcomponents.feature.detail.domain.GenresFormatter
+import com.balocco.androidcomponents.feature.detail.domain.LoadGenresUseCase
 import com.balocco.androidcomponents.feature.detail.domain.LoadMovieUseCase
+import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Single
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -22,19 +29,16 @@ import org.mockito.MockitoAnnotations
 
 class DetailViewModelTest {
 
-    @get:Rule
-    val rule = InstantTaskExecutorRule()
+    @get:Rule val rule = InstantTaskExecutorRule()
 
     private lateinit var viewModel: DetailViewModel
 
-    @Captor
-    private lateinit var movieCaptor: ArgumentCaptor<DetailState>
-
-    @Mock
-    private lateinit var observer: Observer<DetailState>
-
-    @Mock
-    private lateinit var loadMoviesUseCase: LoadMovieUseCase
+    @Captor private lateinit var movieCaptor: ArgumentCaptor<DetailState>
+    @Mock private lateinit var observer: Observer<DetailState>
+    @Mock private lateinit var loadMoviesUseCase: LoadMovieUseCase
+    @Mock private lateinit var fetchGenresUseCase: FetchGenresUseCase
+    @Mock private lateinit var loadGenresUseCase: LoadGenresUseCase
+    @Mock private lateinit var genresFormatter: GenresFormatter
 
     @Before
     fun setUp() {
@@ -42,15 +46,20 @@ class DetailViewModelTest {
         viewModel =
             DetailViewModel(
                 TestSchedulerProvider(),
-                loadMoviesUseCase
+                loadMoviesUseCase,
+                fetchGenresUseCase,
+                loadGenresUseCase,
+                genresFormatter
             )
         viewModel.detailState().observeForever(observer)
     }
 
     @Test
     fun `When started with movie id and successful, notifies success`() {
-        val movie = TestUtils.createMovie("id")
+        val genre = Genre(1, "Action")
+        val movie = TestUtils.createMovie(id = "id", genres = mutableListOf(1))
         whenever(loadMoviesUseCase("id")).thenReturn(Single.just(movie))
+        whenever(loadGenresUseCase(movie.genres)).thenReturn(Flowable.just(listOf(genre)))
 
         viewModel.start("id")
 
@@ -62,8 +71,38 @@ class DetailViewModelTest {
     }
 
     @Test
+    fun `When started with movie id and successful local genres available, notifies success`() {
+        val genres = listOf(Genre(1, "Action"))
+        val movie = TestUtils.createMovie(id = "id", genres = mutableListOf(1))
+        whenever(loadMoviesUseCase("id")).thenReturn(Single.just(movie))
+        whenever(loadGenresUseCase(movie.genres)).thenReturn(Flowable.just(genres))
+        whenever(genresFormatter.toList(genres)).thenReturn("Action")
+
+        viewModel.start("id")
+
+        // Invoked twice when results from genres are received from local storage
+        verify(observer, times(2)).onChanged(movieCaptor.capture())
+        val state = movieCaptor.value
+        assertEquals(State.SUCCESS, state.state)
+        assertEquals(state.movie, movie)
+        assertEquals(state.genres, "Action")
+        assertEquals(0, state.errorMessage)
+    }
+
+    @Test
+    fun `When started with movie id and successful local genres not available, loads genres`() {
+        val movie = TestUtils.createMovie(id = "id", genres = mutableListOf(1))
+        whenever(loadMoviesUseCase("id")).thenReturn(Single.just(movie))
+        whenever(loadGenresUseCase(movie.genres)).thenReturn(Flowable.just(emptyList()))
+        whenever(fetchGenresUseCase()).thenReturn(Completable.complete())
+
+        viewModel.start("id")
+
+        verify(fetchGenresUseCase)()
+    }
+
+    @Test
     fun `When started with movie id and failure, notifies error`() {
-        val movie = TestUtils.createMovie("id")
         whenever(loadMoviesUseCase("id")).thenReturn(Single.error(Throwable()))
 
         viewModel.start("id")

--- a/app/src/test/java/com/balocco/androidcomponents/feature/toprated/domain/FetchTopRatedMoviesUseCaseTest.kt
+++ b/app/src/test/java/com/balocco/androidcomponents/feature/toprated/domain/FetchTopRatedMoviesUseCaseTest.kt
@@ -15,8 +15,7 @@ import org.mockito.MockitoAnnotations
 
 class FetchTopRatedMoviesUseCaseTest {
 
-    @Mock
-    lateinit var moviesRepository: MoviesRepository
+    @Mock lateinit var moviesRepository: MoviesRepository
 
     private lateinit var useCase: FetchTopRatedMoviesUseCase
 

--- a/app/src/test/java/com/balocco/androidcomponents/feature/toprated/viewmodel/TopRatedViewModelTest.kt
+++ b/app/src/test/java/com/balocco/androidcomponents/feature/toprated/viewmodel/TopRatedViewModelTest.kt
@@ -28,25 +28,15 @@ import org.mockito.MockitoAnnotations
 
 class TopRatedViewModelTest {
 
-    @get:Rule
-    val rule = InstantTaskExecutorRule()
+    @get:Rule val rule = InstantTaskExecutorRule()
 
     private lateinit var viewModel: TopRatedViewModel
 
-    @Captor
-    private lateinit var moviesCaptor: ArgumentCaptor<TopRatedState>
-
-    @Mock
-    private lateinit var navigator: Navigator
-
-    @Mock
-    private lateinit var observer: Observer<TopRatedState>
-
-    @Mock
-    private lateinit var fetchTopRatedMoviesUseCase: FetchTopRatedMoviesUseCase
-
-    @Mock
-    private lateinit var loadTopRatedMoviesUseCase: LoadTopRatedMoviesUseCase
+    @Captor private lateinit var moviesCaptor: ArgumentCaptor<TopRatedState>
+    @Mock private lateinit var navigator: Navigator
+    @Mock private lateinit var observer: Observer<TopRatedState>
+    @Mock private lateinit var fetchTopRatedMoviesUseCase: FetchTopRatedMoviesUseCase
+    @Mock private lateinit var loadTopRatedMoviesUseCase: LoadTopRatedMoviesUseCase
 
     @Before
     fun setUp() {


### PR DESCRIPTION
Genres are fetched lazily before showing them. If genres are available locally no network request is executed.